### PR TITLE
Add more filtering rules on carve target functions

### DIFF
--- a/bin/tools/utils.py
+++ b/bin/tools/utils.py
@@ -3,97 +3,103 @@
 import sys, os
 import subprocess as sp
 
-def check_given_bitcode(inputbc):
-  #check given file exists
-  if not os.path.isfile(inputbc):
-    print("Can't find file : {}".format(inputbc))
-    return False
 
-  #check given file format
-  cmd = ["file", inputbc]
-  stdout = sp.run(cmd, stdout=sp.PIPE, stderr=sp.DEVNULL).stdout
-  if b"bitcode" not in stdout:
-    print("Can't recognize file : {}".format(inputbc))
-    return False
-  
-  return True
+def check_given_bitcode(inputbc):
+    # check given file exists
+    if not os.path.isfile(inputbc):
+        print("Can't find file : {}".format(inputbc))
+        return False
+
+    # check given file format
+    cmd = ["file", inputbc]
+    stdout = sp.run(cmd, stdout=sp.PIPE, stderr=sp.DEVNULL).stdout
+    if b"bitcode" not in stdout:
+        print("Can't recognize file : {}".format(inputbc))
+        return False
+
+    return True
 
 
 def get_ld_path():
-  cmd = ["llvm-config", "--bindir"]
-  out = sp.run(cmd, stdout=sp.PIPE, stderr=sp.PIPE)
+    cmd = ["llvm-config", "--bindir"]
+    out = sp.run(cmd, stdout=sp.PIPE, stderr=sp.PIPE)
 
-  if b"command not found" in out.stderr:
-    print("Can't find llvm-config, please check PATH")
-    exit()
+    if b"command not found" in out.stderr:
+        print("Can't find llvm-config, please check PATH")
+        exit()
 
-  ld_path = out.stdout.decode()[:-1] + "/ld.lld"
-  return ld_path
+    ld_path = out.stdout.decode()[:-1] + "/ld.lld"
+    return ld_path
+
 
 def read_carved_func_type(type_infof):
-  type_info = dict() # func_name -> [(var_name, type_name)]
-  types = set()
-  with open(type_infof, "r") as f1:
-    funcname = ""
-    for line in f1:
-      if line.startswith("##"):
-        funcname = line.strip()[2:]
-      elif line.startswith("**"):
-        line = line.strip().split(" : ")
-        var_name = line[0][2:]
-        type_name = line[1]
-        if funcname not in type_info:
-          type_info[funcname] = []
-        type_info[funcname].append((var_name, type_name))
-        types.add(type_name)
-      else:
-        print("Wrong format!\n")
-        break
-  
-  return type_info, types
+    type_info = dict()  # func_name -> [(var_name, type_name)]
+    types = set()
+    with open(type_infof, "r") as f1:
+        funcname = ""
+        for line in f1:
+            if line.startswith("##"):
+                funcname = line.strip()[2:]
+            elif line.startswith("**"):
+                line = line.strip().split(" : ")
+                var_name = line[0][2:]
+                type_name = line[1]
+                if funcname not in type_info:
+                    type_info[funcname] = []
+                type_info[funcname].append((var_name, type_name))
+                types.add(type_name)
+            else:
+                print("Wrong format!\n")
+                break
+
+    return type_info, types
+
 
 def get_link_option(input_bc_filename):
-  orig_filename = ".".join(input_bc_filename.split(".")[:-1])
+    orig_filename = ".".join(input_bc_filename.split(".")[:-1])
 
-  cmd = ["ldd", orig_filename]
+    cmd = ["ldd", orig_filename]
 
-  out = sp.run(cmd, stdout=sp.PIPE, stderr=sp.PIPE).stdout.decode()
+    out = sp.run(cmd, stdout=sp.PIPE, stderr=sp.PIPE).stdout.decode()
 
-  link_commands = []
+    link_commands = []
 
-  for line in out.split("\n"):
-    if "linux-vdso.so" in line:
-      continue
-    if "libgcc_s.so" in line:
-      continue
-    if "ld-linux-x86-64.so" in line:
-      continue
-    if "libc.so" in line:
-      continue
+    for line in out.split("\n"):
+        if "linux-vdso.so" in line:
+            continue
+        if "libgcc_s.so" in line:
+            continue
+        if "ld-linux-x86-64.so" in line:
+            continue
+        if "libc.so" in line:
+            continue
 
-    if "=>" not in line:
-      continue
+        if "=>" not in line:
+            continue
 
-    line = line.strip().split("=>")[0]
+        line = line.strip().split("=>")[0]
 
-    if "lib" not in line and "so" not in line:
-      continue
+        if "lib" not in line and "so" not in line:
+            continue
 
-    so_name = line.split("lib")[1].split(".so")[0]
-    link_commands.append("-l" + so_name)
+        so_name = line.split("lib")[1].split(".so")[0]
+        link_commands.append("-l" + so_name)
 
-  return (link_commands)
+    return link_commands
+
 
 def get_clang_version():
-  cmd = ["clang++", "--version"]
-  out = sp.run(cmd, stdout=sp.PIPE, stderr=sp.PIPE).stdout.decode()
-  version = int(out.split(" ")[2].split(".")[0])
-  return version
+    cmd = ["clang++", "--version"]
+    out = sp.run(cmd, stdout=sp.PIPE, stderr=sp.PIPE).stdout.decode()
+    tokens = out.split()
+    version = tokens[tokens.index("version") + 1].split(".")[0]
+    return version
+
 
 def need_asan_flag(input_bc_filename):
-  orig_filename = ".".join(input_bc_filename.split(".")[:-1])
+    orig_filename = ".".join(input_bc_filename.split(".")[:-1])
 
-  cmd = ["nm", orig_filename]
-  out = sp.run(cmd, stdout=sp.PIPE, stderr=sp.PIPE).stdout.decode()
+    cmd = ["nm", orig_filename]
+    out = sp.run(cmd, stdout=sp.PIPE, stderr=sp.PIPE).stdout.decode()
 
-  return "__asan_report" in out
+    return "__asan_report" in out

--- a/src/carving/carve_func_args_pass.cc
+++ b/src/carving/carve_func_args_pass.cc
@@ -403,6 +403,14 @@ void carver_pass::get_instrument_func_set() {
 
   // Otherwise
   for (auto &F : Mod->functions()) {
+    llvm::DISubprogram *dbgF = F.getSubprogram();
+    if (dbgF == NULL) {
+      continue;
+    }
+    std::string filename = F.getSubprogram()->getFilename().str();
+    if (filename.find("gcc/") != std::string::npos) {
+      continue;
+    }
 
     if (F.isIntrinsic() || !F.size()) {
       continue;

--- a/src/carving/carve_func_args_pass.cc
+++ b/src/carving/carve_func_args_pass.cc
@@ -419,7 +419,7 @@ void carver_pass::get_instrument_func_set() {
     if (func_name.find("_GLOBAL__sub_I_") != std::string::npos) {
       continue;
     }
-    if (func_name == "__cxx_global_var_init") {
+    if (func_name.find("__cxx_global_var_init") != std::string::npos) {
       continue;
     }
     if (func_name.find("llvm_gcov") != std::string::npos) {


### PR DESCRIPTION
New fIltering rules:
- If the function defined in `*/gcc/*`, ignore it.
- If function has `__cxx_global_var_init` as a substring, ignore it (was equal, not substring in previous version)